### PR TITLE
import colyseus.js/decentraland fixed on 0.15.10

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,0 @@
-declare module 'colyseus.js/decentraland' {
-  import * as colyseus from 'colyseus.js'
-  export = colyseus
-}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@dcl-sdk/utils": "^1.1.2",
-    "colyseus.js": "^0.15.8",
+    "colyseus.js": "^0.15.10",
     "core-js": "^3.31.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { executeTask } from '@dcl/sdk/ecs'
 import './polyfill'
 
-import { Client } from 'colyseus.js/decentraland'
+import { Client } from 'colyseus.js'
 const ENDPOINT = 'wss://your-colyeus-endpoint:8000'
 
 executeTask(async () => {


### PR DESCRIPTION
- import directly from `colyseus.js` 
- remove `colyseus.js/decentraland` TypeScript alias

this version uses `fetch` by default instead of `XMLHttpRequest` (https://github.com/colyseus/colyseus.js/releases/tag/0.15.10)